### PR TITLE
Fix analysis retry logic

### DIFF
--- a/SwiftUI_class_final_project/AnalysisView.swift
+++ b/SwiftUI_class_final_project/AnalysisView.swift
@@ -122,7 +122,6 @@ struct AnalysisView: View {
         resultText = ""
         isError = false
         isLoading = true
-        retryCount += 1
         loadAllergens()
 
         if mode == .image, let image = image {
@@ -144,10 +143,12 @@ struct AnalysisView: View {
                 resultText = text
                 isError = false
                 historyVM.addCard(image: image, result: text, allergens: allergensSelection)
+                retryCount = 0
             case .failure(let error):
                 resultText = "錯誤：\(error.localizedDescription)\n請點擊「再試一次」"
 //                resultText = "請點擊「再試一次」"
                 isError = true
+                retryCount += 1
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix retry behavior so the view doesn't reset on every attempt

## Testing
- `swift --version`
- `swiftc SwiftUI_class_final_project/AnalysisView.swift -o /tmp/out 2>&1 | head` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6842c57c3bd88327b1bd70e1de377be9